### PR TITLE
perf: :zap: use Bunny Fonts for fonts rather than self-host

### DIFF
--- a/src/components/SiteHead.astro
+++ b/src/components/SiteHead.astro
@@ -52,7 +52,10 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <meta property="twitter:image" content="https://astro.build/social.png?v=1" />
 
 <link rel="preconnect" href="https://fonts.bunny.net" />
-<link href="https://fonts.bunny.net/css" rel="stylesheet" />
+<link
+  href="https://fonts.bunny.net/css?family=jetbrains-mono:400|josefin-sans:500,500i,700,700i|josefin-slab:500,500i,600,600i,700,700i"
+  rel="stylesheet"
+/>
 
 <link
   rel="stylesheet"

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,5 +1,8 @@
 @import "node_modules/normalize.css/normalize";
-@import "./base/fonts";
+
+// fonts for if ever want to self-host
+// @import "./base/fonts";
+
 @import "./base/mixins";
 @import "./base/properties";
 @import "./base/reset";


### PR DESCRIPTION
Gone back and forth on this, but going to use Bunny Fonts for retrieving my custom fonts, because;

1. It uses unicode ranges to use relevant fonts
2. It has generally great performance
3. It removes one extra thing for me to investigate and maintain

I might go back to self-hosting one day, but this makes sense at the mo.